### PR TITLE
Use Kahn's algorithm for topological sort

### DIFF
--- a/microcosm_resourcesync/endpoints/http_endpoint.py
+++ b/microcosm_resourcesync/endpoints/http_endpoint.py
@@ -120,17 +120,13 @@ class HTTPEndpoint(Endpoint):
         for resource in resource_batch:
             self.write_resource(resource, **kwargs)
 
-    def write_resource_batch(self, resource_batch, formatter, max_attempts, **kwargs):
+    def write_resource_batch(self, resource_batch, formatter, max_attempts=2, verbose=False, **kwargs):
         """
         Write resources in a batch.
 
         Uses the microcosm `BatchUpdate` convention to PATCH the base collection URI.
 
         """
-        data = formatter.value.dump(dict(
-            items=resource_batch,
-        ))
-
         uri = commonprefix([
             self.join_uri(resource.uri)
             for resource in resource_batch
@@ -140,6 +136,13 @@ class HTTPEndpoint(Endpoint):
 
         if "PATCH" not in allowed_methods:
             raise BatchingNotSupported()
+
+        if verbose:
+            echo("Batch updating resource(s) for: {}".format(uri), err=True)
+
+        data = formatter.value.dump(dict(
+            items=resource_batch,
+        ))
 
         response = self.retry(
             self.session.patch,

--- a/microcosm_resourcesync/tests/test_toposort.py
+++ b/microcosm_resourcesync/tests/test_toposort.py
@@ -2,6 +2,8 @@
 Toposort test.
 
 """
+from random import shuffle
+
 from hamcrest import (
     assert_that,
     contains,
@@ -14,40 +16,80 @@ from microcosm_resourcesync.toposort import toposorted
 resources = [
     SimpleSchema(
         id=1,
-        type="foo",
-        uri="http://example.com/foo/1",
+        type="parent",
+        uri="http://example.com/parent/1",
     ),
     SimpleSchema(
         id=2,
-        type="foo",
-        uri="http://example.com/foo/2",
+        type="child",
+        uri="http://example.com/child/2",
         parents=[
-            "http://example.com/foo/1",
+            "http://example.com/parent/1",
         ],
     ),
     SimpleSchema(
         id=3,
-        type="foo",
-        uri="http://example.com/foo/3",
+        type="grandchild",
+        uri="http://example.com/grandchild/3",
+        parents=[
+            "http://example.com/child/2",
+        ],
     ),
     SimpleSchema(
-        id=1,
-        type="bar",
-        uri="http://example.com/bar/1",
+        id=4,
+        type="grandchild",
+        uri="http://example.com/grandchild/4",
         parents=[
-            "http://example.com/foo/1",
+            "http://example.com/child/2",
+        ],
+    ),
+    SimpleSchema(
+        id=5,
+        type="child",
+        uri="http://example.com/child/5",
+        parents=[
+            "http://example.com/parent/1",
+        ],
+    ),
+    SimpleSchema(
+        id=6,
+        type="grandchild",
+        uri="http://example.com/grandchild/6",
+        parents=[
+            "http://example.com/child/5",
+        ],
+    ),
+    SimpleSchema(
+        id=7,
+        type="grandchild",
+        uri="http://example.com/grandchild/7",
+        parents=[
+            "http://example.com/child/5",
         ],
     ),
 ]
 
 
+def shuffled(lst):
+    """
+    Copy and shuffle.
+
+    """
+    result = list(lst)
+    shuffle(result)
+    return result
+
+
 def test_toposort():
     assert_that(
-        toposorted(resources),
+        toposorted(shuffled(resources)),
         contains(
-            resources[2],
             resources[0],
             resources[1],
+            resources[4],
+            resources[2],
             resources[3],
+            resources[5],
+            resources[6],
         ),
     )

--- a/microcosm_resourcesync/toposort.py
+++ b/microcosm_resourcesync/toposort.py
@@ -5,35 +5,16 @@ Topological sort.
 from collections import defaultdict
 
 
-TEMPORARY = object()
-VISITED = object()
-
-
-def visit(nodes, edges, visited, results, resource):
-    """
-    DFS visit function.
-
-    """
-    if visited.get(resource.uri) == VISITED:
-        return
-
-    if visited.get(resource.uri) == TEMPORARY:
-        raise Exception("Found cycle at {}".format(resource.uri))
-
-    visited[resource.uri] = TEMPORARY
-    for child_uri in edges[resource.uri]:
-        child = nodes[child_uri]
-        visit(nodes, edges, visited, results, child)
-    visited[resource.uri] = VISITED
-
-    results.append(resource)
-
-
 def toposorted(resources):
     """
     Perform a topological sort on the input resources.
 
-    Uses a DFS.
+    Resources are first sorted by type and id to generate a deterministic ordering and to group
+    resouces of the same type together (which minimizes the number of write operations required
+    when batching together writes of the same type).
+
+    The topological sort uses Kahn's algorithm, which is a stable sort and will preserve this
+    ordering; note that a DFS will produce a worst case ordering from the perspective of batching.
 
     """
     # sort resources first so we have a deterministic order of nodes with the same partial order
@@ -42,15 +23,29 @@ def toposorted(resources):
         key=lambda resource: (resource.type, resource.id),
     )
 
-    # build graph
-    nodes, edges = dict(), defaultdict(list)
+    # build incoming and outgoing edges
+    incoming = defaultdict(set)
+    outgoing = defaultdict(set)
     for resource in resources:
-        nodes[resource.uri] = resource
-        for parent_uri in resource.parents:
-            edges[parent_uri].append(resource.uri)
+        for parent in resource.parents:
+            incoming[resource.uri].add(parent)
+            outgoing[parent].add(resource.uri)
 
-    # DFS
-    results, visited = [], {}
-    for resource in resources:
-        visit(nodes, edges, visited, results, resource)
-    return reversed(results)
+    results = []
+    while resources:
+        remaining = []
+        for resource in resources:
+            if incoming[resource.uri]:
+                # node still has incoming edges
+                remaining.append(resource)
+                continue
+
+            results.append(resource)
+            for child in outgoing[resource.uri]:
+                incoming[child].remove(resource.uri)
+
+        if len(resources) == len(remaining):
+            raise Exception("Cycle detected")
+        resources = remaining
+
+    return results

--- a/microcosm_resourcesync/toposort.py
+++ b/microcosm_resourcesync/toposort.py
@@ -24,10 +24,17 @@ def toposorted(resources):
     )
 
     # build incoming and outgoing edges
+    nodes = {
+        resource.uri
+        for resource in resources
+    }
     incoming = defaultdict(set)
     outgoing = defaultdict(set)
     for resource in resources:
         for parent in resource.parents:
+            if parent not in nodes:
+                # ignore references that lead outside of the current graph
+                continue
             incoming[resource.uri].add(parent)
             outgoing[parent].add(resource.uri)
 


### PR DESCRIPTION
Switching away from DFS so that we get sort stability.

With a stable sort, the usual case of resource parent-child relationships that follow type definitions (`Employee` is a child of `Company`) are very likely to result in resources of the same type being adjacent in the sorted results, which reduces the number of writes required when batching by type is enabled.

On the other hand, DFS is almost by definition going to give us worst case batching behavior because child resources will be clustered near their parents (which often have different types).