### PR TITLE
GLOB-6731: Support (document) using libyaml for faster performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ This process is especially useful if the intermediate format lives in version co
 and merging well.
 
 
+## Installation
+
+Install into a virtualenv:
+
+    mkvirtualenv microcosm-resourcesync --python=python3
+    pip install -e .
+
+
+## Using libyaml
+
+YAML performance is significantly better using `libyaml`. On OSX:
+
+    brew install yaml-cpp libyaml
+    pip uninstall PyYAML
+    # installing with pip appears not to work
+    python -m easy_install pyyaml
+
+
 ## Usage
 
 The main usage is synchronizes from one or more `origin` endpoint to a `destination` endpoint:

--- a/microcosm_resourcesync/endpoints/__init__.py
+++ b/microcosm_resourcesync/endpoints/__init__.py
@@ -6,6 +6,7 @@ from os.path import abspath, exists, split
 
 from microcosm_resourcesync.endpoints.directory_endpoint import DirectoryEndpoint
 from microcosm_resourcesync.endpoints.http_endpoint import HTTPEndpoint
+from microcosm_resourcesync.endpoints.null_endpoint import NullEndpoint
 from microcosm_resourcesync.endpoints.pipe_endpoint import PipeEndpoint
 from microcosm_resourcesync.endpoints.yaml_file_endpoint import YAMLFileEndpoint
 
@@ -17,6 +18,9 @@ def endpoint_for(endpoint):
     """
     if endpoint == "-":
         return PipeEndpoint()
+
+    if endpoint == "null" or endpoint == "/dev/null":
+        return NullEndpoint()
 
     if endpoint.startswith("http://") or endpoint.startswith("https://"):
         return HTTPEndpoint(endpoint)

--- a/microcosm_resourcesync/endpoints/directory_endpoint.py
+++ b/microcosm_resourcesync/endpoints/directory_endpoint.py
@@ -44,7 +44,9 @@ class DirectoryEndpoint(Endpoint):
                 _, ext = splitext(filename)
                 formatter = Formatters.for_extension(ext).value
                 with open(join(dirpath, filename), "r") as file_:
-                    yield schema_cls(formatter.load(file_.read()))
+                    data = file_.read()
+                    dct = formatter.load(data)
+                    yield schema_cls(dct)
 
     def write(self, resources, formatter, remove=False, **kwargs):
         """

--- a/microcosm_resourcesync/endpoints/null_endpoint.py
+++ b/microcosm_resourcesync/endpoints/null_endpoint.py
@@ -1,0 +1,27 @@
+"""
+Endpoint interface
+
+"""
+from microcosm_resourcesync.endpoints.base import Endpoint
+
+
+class NullEndpoint(Endpoint):
+
+    def read(self, schema_cls, **kwargs):
+        """
+        Generate resources of the given schema.
+
+        """
+        return []
+
+    def write(self, resources, formatter, **kwargs):
+        """
+        Write resources using the given formatter.
+
+        """
+        pass
+
+    def __repr__(self):
+        return "{}()".format(
+            self.__class__.__name__,
+        )

--- a/microcosm_resourcesync/formatters/yaml_formatter.py
+++ b/microcosm_resourcesync/formatters/yaml_formatter.py
@@ -2,11 +2,11 @@
 YAML Formatter
 
 """
-from yaml import load, safe_dump
+from yaml import dump, load
 try:
-    from yaml import CSafeLoader as SafeLoader
+    from yaml import CSafeDumper as SafeDumper, CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import SafeLoader
+    from yaml import SafeDumper, SafeLoader
 
 from microcosm_resourcesync.formatters.base import Formatter
 
@@ -17,7 +17,7 @@ class YAMLFormatter(Formatter):
         return load(data, Loader=SafeLoader)
 
     def dump(self, dct):
-        return safe_dump(
+        return dump(
             dict(dct),
             # show every document in its own block
             default_flow_style=False,
@@ -26,6 +26,7 @@ class YAMLFormatter(Formatter):
             # follow (modern) PEP8 max line length and indent
             width=99,
             indent=4,
+            Dumper=SafeDumper,
         )
 
     @property

--- a/microcosm_resourcesync/formatters/yaml_formatter.py
+++ b/microcosm_resourcesync/formatters/yaml_formatter.py
@@ -2,7 +2,11 @@
 YAML Formatter
 
 """
-from yaml import safe_dump, safe_load
+from yaml import load, safe_dump
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
 
 from microcosm_resourcesync.formatters.base import Formatter
 
@@ -10,7 +14,7 @@ from microcosm_resourcesync.formatters.base import Formatter
 class YAMLFormatter(Formatter):
 
     def load(self, data):
-        return safe_load(data)
+        return load(data, Loader=SafeLoader)
 
     def dump(self, dct):
         return safe_dump(


### PR DESCRIPTION
Loading a directory of a few thousand YAML files was taking ten or more seconds;
with the `libyaml` extension it takes one or two seconds.

Getting libyaml to work on OSX is a little tricky...