### PR TITLE
Resource-sync needs six to work.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "enum34>=1.1.6",
         "PyYAML>=3.12",
         "requests>=2.13.0",
+        "six>=1.1.10",
     ],
     setup_requires=[
         "nose>=1.3.7",


### PR DESCRIPTION
Before:

```
(sixtest) ✔ 11:05 ~/globality/microcosm-resourcesync [feature/fix-missing-six-dep L|✔] $ resource-sync uri -
Traceback (most recent call last):
  File "/Users/dino/.virtualenvs/sixtest/bin/resource-sync", line 11, in <module>
    load_entry_point('microcosm-resourcesync', 'console_scripts', 'resource-sync')()
  File "/Users/dino/.virtualenvs/sixtest/lib/python3.6/site-packages/pkg_resources/__init__.py", line 564, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/dino/.virtualenvs/sixtest/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2662, in load_entry_point
    return ep.load()
  File "/Users/dino/.virtualenvs/sixtest/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2316, in load
    return self.resolve()
  File "/Users/dino/.virtualenvs/sixtest/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2322, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/dino/globality/microcosm-resourcesync/microcosm_resourcesync/main.py", line 15, in <module>
    from microcosm_resourcesync.endpoints import endpoint_for
  File "/Users/dino/globality/microcosm-resourcesync/microcosm_resourcesync/endpoints/__init__.py", line 7, in <module>
    from microcosm_resourcesync.endpoints.directory_endpoint import DirectoryEndpoint
  File "/Users/dino/globality/microcosm-resourcesync/microcosm_resourcesync/endpoints/directory_endpoint.py", line 11, in <module>
    from microcosm_resourcesync.endpoints.base import Endpoint
  File "/Users/dino/globality/microcosm-resourcesync/microcosm_resourcesync/endpoints/base.py", line 7, in <module>
    from six import add_metaclass
ModuleNotFoundError: No module named 'six'
```

With this it works.
