### PR TITLE
Remove python2isms

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.1
+current_version = 1.0.0
 commit = False
 tag = False
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 
 machine:
   python:
-      version: 2.7.11
+      version: 3.6.2
 
 general:
   artifacts:
@@ -12,7 +12,7 @@ general:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.5.2  # Should correspond to pre-installed Python versions on CircleCI
+    - pyenv local 3.6.2
 
 test:
   override:

--- a/microcosm_resourcesync/endpoints/base.py
+++ b/microcosm_resourcesync/endpoints/base.py
@@ -4,13 +4,11 @@ Endpoint interface
 """
 from abc import ABCMeta, abstractmethod
 from os import makedirs
-from six import add_metaclass
 
 from microcosm_resourcesync.formatters import Formatters
 
 
-@add_metaclass(ABCMeta)
-class Endpoint(object):
+class Endpoint(metaclass=ABCMeta):
     """
     An endpoint is able to read and write resources.
 

--- a/microcosm_resourcesync/endpoints/http_endpoint.py
+++ b/microcosm_resourcesync/endpoints/http_endpoint.py
@@ -3,7 +3,7 @@ HTTP endpoint.
 
 """
 from os.path import commonprefix
-from six.moves.urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse
 from sys import stderr
 
 from click import echo, progressbar

--- a/microcosm_resourcesync/formatters/base.py
+++ b/microcosm_resourcesync/formatters/base.py
@@ -3,11 +3,9 @@ Formatter interface
 
 """
 from abc import ABCMeta, abstractmethod, abstractproperty
-from six import add_metaclass
 
 
-@add_metaclass(ABCMeta)
-class Formatter(object):
+class Formatter(metaclass=ABCMeta):
     """
     A format encodes a resource to/from a dictionary.
 

--- a/microcosm_resourcesync/schemas/base.py
+++ b/microcosm_resourcesync/schemas/base.py
@@ -4,14 +4,12 @@ Schema interface.
 """
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import namedtuple
-from six import add_metaclass
 
 
 Link = namedtuple("Link", ["relation", "uri"])
 
 
-@add_metaclass(ABCMeta)
-class Schema(dict):
+class Schema(dict, metaclass=ABCMeta):
     """
     A schema wraps a dictionary and defines a `uri`, `id`, `type`, etc.
 

--- a/microcosm_resourcesync/tests/endpoints/test_http_endpoint.py
+++ b/microcosm_resourcesync/tests/endpoints/test_http_endpoint.py
@@ -51,7 +51,7 @@ def set_response(mock, *resources):
     ]
 
 
-class TestHTTPEndpoint(object):
+class TestHTTPEndpoint:
 
     def setup(self):
         self.uri = "http://example.com/api"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-resourcesync"
-version = "0.8.1"
+version = "1.0.0"
 
 setup(
     name=project,
@@ -19,8 +19,7 @@ setup(
         "click>=6.7",
         "enum34>=1.1.6",
         "PyYAML>=3.12",
-        "requests>=2.13.0",
-        "six>=1.1.10",
+        "requests>=2.18.4",
     ],
     setup_requires=[
         "nose>=1.3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, lint
+envlist = py36, lint
 
 [testenv]
 commands =
@@ -10,7 +10,7 @@ deps =
 
 [testenv:lint]
 commands=flake8 microcosm_resourcesync
-basepython=python2.7
+basepython=python3.6
 deps=
     flake8
     flake8-print


### PR DESCRIPTION
 - Build only 3.6
 - Remove six usage
 - Remove legacy class-object inheritance
 - Bump major version