### PR TITLE
Simple fix for strict validation

### DIFF
--- a/microcosm_resourcesync/endpoints/http_endpoint.py
+++ b/microcosm_resourcesync/endpoints/http_endpoint.py
@@ -153,7 +153,10 @@ class HTTPEndpoint(Endpoint):
             echo("Batch updating resource(s) for: {}".format(uri), err=True)
 
         data = formatter.value.dump(dict(
-            items=resource_batch,
+            items=[
+                resource.to_http_data()
+                for resource in resource_batch
+            ],
         ))
 
         response = self.retry(
@@ -188,12 +191,11 @@ class HTTPEndpoint(Endpoint):
 
         """
         uri = self.join_uri(resource.uri)
-        data = formatter.value.dump(resource)
+        data = formatter.value.dump(resource.to_http_data())
 
         # NB: verbose logging the message content is obnoxius and interferes with the
         # progressbar; if we need more information here, we probably need more levels
         # of verbosity and a more traditional progress bar
-
         response = self.retry(
             self.session.put,
             uri=uri,

--- a/microcosm_resourcesync/endpoints/http_endpoint.py
+++ b/microcosm_resourcesync/endpoints/http_endpoint.py
@@ -154,7 +154,7 @@ class HTTPEndpoint(Endpoint):
 
         data = formatter.value.dump(dict(
             items=[
-                resource.to_http_data()
+                resource.to_filtered_body()
                 for resource in resource_batch
             ],
         ))
@@ -191,7 +191,7 @@ class HTTPEndpoint(Endpoint):
 
         """
         uri = self.join_uri(resource.uri)
-        data = formatter.value.dump(resource.to_http_data())
+        data = formatter.value.dump(resource.to_filtered_body())
 
         # NB: verbose logging the message content is obnoxius and interferes with the
         # progressbar; if we need more information here, we probably need more levels

--- a/microcosm_resourcesync/schemas/base.py
+++ b/microcosm_resourcesync/schemas/base.py
@@ -14,6 +14,9 @@ class Schema(dict, metaclass=ABCMeta):
     A schema wraps a dictionary and defines a `uri`, `id`, `type`, etc.
 
     """
+    def to_http_data(self):
+        return self
+
     @property
     def id(self):
         """

--- a/microcosm_resourcesync/schemas/base.py
+++ b/microcosm_resourcesync/schemas/base.py
@@ -14,7 +14,7 @@ class Schema(dict, metaclass=ABCMeta):
     A schema wraps a dictionary and defines a `uri`, `id`, `type`, etc.
 
     """
-    def to_http_data(self):
+    def to_filtered_body(self):
         return self
 
     @property

--- a/microcosm_resourcesync/schemas/hal_schema.py
+++ b/microcosm_resourcesync/schemas/hal_schema.py
@@ -5,12 +5,31 @@ A schema using HAL JSON linking conventions.
 from microcosm_resourcesync.following import FollowMode
 from microcosm_resourcesync.schemas.base import Link, Schema
 
+HTTP_EXCLUDED_KEYS = ["id", "_links"]
+
 
 class HALSchema(Schema):
     """
     A schema that implements HAL JSON linking.
 
     """
+    def to_http_data(self):
+        """
+        We now use marshmallow 3, which means strict validation of input.
+        Extra fields trigger 422 errors; there are some keys that we know will
+        never be part of an input resource, remove them here.
+
+        Note: the general solution would be to pass in a separate schema for every resource
+        we deal with; this is a simpler fix that works with how we use `microcosm-resourcesync`
+        in practice. It may not always work.
+
+        """
+        return {
+            key: value
+            for key, value in self.items()
+            if key not in HTTP_EXCLUDED_KEYS
+        }
+
     @property
     def embedded(self):
         return self.get("items", [])

--- a/microcosm_resourcesync/schemas/hal_schema.py
+++ b/microcosm_resourcesync/schemas/hal_schema.py
@@ -13,7 +13,7 @@ class HALSchema(Schema):
     A schema that implements HAL JSON linking.
 
     """
-    def to_http_data(self):
+    def to_filtered_body(self):
         """
         We now use marshmallow 3, which means strict validation of input.
         Extra fields trigger 422 errors; there are some keys that we know will

--- a/microcosm_resourcesync/tests/endpoints/test_http_endpoint.py
+++ b/microcosm_resourcesync/tests/endpoints/test_http_endpoint.py
@@ -185,7 +185,7 @@ class TestHTTPEndpoint:
             mocked_put.assert_any_call(
                 resource.uri,
                 auth=None,
-                data=Formatters.JSON.value.dump(resource.to_http_data()),
+                data=Formatters.JSON.value.dump(resource.to_filtered_body()),
                 headers={'Content-Type': 'application/json'}
             )
 
@@ -215,7 +215,7 @@ class TestHTTPEndpoint:
             "http://example.com/api/foo",
             auth=None,
             data=Formatters.JSON.value.dump(dict(
-                items=[item.to_http_data() for item in resources[0:2]],
+                items=[item.to_filtered_body() for item in resources[0:2]],
             )),
             headers={'Content-Type': 'application/json'}
         )
@@ -223,7 +223,7 @@ class TestHTTPEndpoint:
             "http://example.com/api/foo",
             auth=None,
             data=Formatters.JSON.value.dump(dict(
-                items=[item.to_http_data() for item in resources[2:]],
+                items=[item.to_filtered_body() for item in resources[2:]],
             )),
             headers={'Content-Type': 'application/json'}
         )

--- a/microcosm_resourcesync/tests/endpoints/test_http_endpoint.py
+++ b/microcosm_resourcesync/tests/endpoints/test_http_endpoint.py
@@ -185,7 +185,7 @@ class TestHTTPEndpoint:
             mocked_put.assert_any_call(
                 resource.uri,
                 auth=None,
-                data=Formatters.JSON.value.dump(resource),
+                data=Formatters.JSON.value.dump(resource.to_http_data()),
                 headers={'Content-Type': 'application/json'}
             )
 
@@ -215,7 +215,7 @@ class TestHTTPEndpoint:
             "http://example.com/api/foo",
             auth=None,
             data=Formatters.JSON.value.dump(dict(
-                items=resources[0:2],
+                items=[item.to_http_data() for item in resources[0:2]],
             )),
             headers={'Content-Type': 'application/json'}
         )
@@ -223,7 +223,7 @@ class TestHTTPEndpoint:
             "http://example.com/api/foo",
             auth=None,
             data=Formatters.JSON.value.dump(dict(
-                items=resources[2:],
+                items=[item.to_http_data() for item in resources[2:]],
             )),
             headers={'Content-Type': 'application/json'}
         )


### PR DESCRIPTION
**Why?**
We have switched to marshmallow 3, which uses strict schema validation. This means that any unexpected field sent in a request triggers a `422`.
`microcosm-resourcesync` assumes that it can take a resource and send all of it to a new endpoint, which doesn't work with strict validation.

**What?**

Filter out `id` and `_links` fields before sending the resource. This should work with a YAML file source, and won't work in general with an HTTP source. In practice though, we only use `microcosm-resourcesync` in two places (see https://github.com/globality-corp/miranda/blob/develop/miranda/data/cli/synchronize.py and https://github.com/globality-corp/blanca/blob/develop/blanca/data/main.py), and both use a YAML file as a source.